### PR TITLE
fix: Redis 캐시 역직렬화 안정성을 위한 RestPage DTO 개선

### DIFF
--- a/src/main/java/be/kicksync_backend/common/dto/RestPage.java
+++ b/src/main/java/be/kicksync_backend/common/dto/RestPage.java
@@ -1,19 +1,22 @@
 package be.kicksync_backend.common.dto;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 import java.util.List;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RestPage<T> {
 
-    private final List<T> content;
-    private final int page;
-    private final int size;
-    private final long totalElements;
-    private final int totalPages;
-    private final boolean first;
-    private final boolean last;
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean first;
+    private boolean last;
 
     public RestPage(Page<T> page) {
         this.content = page.getContent();
@@ -24,5 +27,4 @@ public class RestPage<T> {
         this.first = page.isFirst();
         this.last = page.isLast();
     }
-
 }


### PR DESCRIPTION
## What is this PR?

PageImpl 상속 구조에서 발생하는 역직렬화 에러를 방지하기 위해 상속 대신 합성 구조를 채택, Jackson 역직렬화에 필요한 기본 생성자를 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 페이지네이션 관련 내부 구조를 개선하여 더 나은 유연성을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->